### PR TITLE
Dashboard: drag-to-reorder cards, feeling slider polish

### DIFF
--- a/app/assets/stylesheets/custom/memberships.css
+++ b/app/assets/stylesheets/custom/memberships.css
@@ -35,9 +35,9 @@
 /* Feeling slider */
 
 @keyframes label-dismiss {
-  0%   { opacity: 1; transform: translate(-50%, 0)     scale(1);    }
-  40%  { opacity: 1; transform: translate(-50%, 0)     scale(1.06); }
-  100% { opacity: 0; transform: translate(-50%, -10px) scale(1.6);  }
+  0%   { opacity: 1;   transform: translate(-50%, 0px)   scale(1);    }
+  18%  { opacity: 1;   transform: translate(-50%, -3px)  scale(1.45); }
+  100% { opacity: 0;   transform: translate(-50%, -20px) scale(0.9);  }
 }
 
 @keyframes spark-fly {

--- a/app/assets/stylesheets/custom/memberships.css
+++ b/app/assets/stylesheets/custom/memberships.css
@@ -34,6 +34,12 @@
 
 /* Feeling slider */
 
+@keyframes label-dismiss {
+  0%   { opacity: 1; transform: translate(-50%, 0)    scale(1);    }
+  25%  { opacity: 1; transform: translate(-50%, 0)    scale(1.08); }
+  100% { opacity: 0; transform: translate(-50%, -8px) scale(1.55); }
+}
+
 @keyframes spark-fly {
   0%   { transform: translate(-50%, -50%) scale(1); opacity: 1; }
   100% { transform: translate(calc(-50% + var(--tx)), calc(-50% + var(--ty))) scale(0); opacity: 0; }

--- a/app/assets/stylesheets/custom/memberships.css
+++ b/app/assets/stylesheets/custom/memberships.css
@@ -35,9 +35,9 @@
 /* Feeling slider */
 
 @keyframes label-dismiss {
-  0%   { opacity: 1; transform: translate(-50%, 0)    scale(1);    }
-  25%  { opacity: 1; transform: translate(-50%, 0)    scale(1.08); }
-  100% { opacity: 0; transform: translate(-50%, -8px) scale(1.55); }
+  0%   { opacity: 1; transform: translate(-50%, 0)     scale(1);    }
+  40%  { opacity: 1; transform: translate(-50%, 0)     scale(1.06); }
+  100% { opacity: 0; transform: translate(-50%, -10px) scale(1.6);  }
 }
 
 @keyframes spark-fly {

--- a/app/assets/stylesheets/custom/memberships.css
+++ b/app/assets/stylesheets/custom/memberships.css
@@ -34,6 +34,11 @@
 
 /* Feeling slider */
 
+@keyframes spark-fly {
+  0%   { transform: translate(-50%, -50%) scale(1); opacity: 1; }
+  100% { transform: translate(calc(-50% + var(--tx)), calc(-50% + var(--ty))) scale(0); opacity: 0; }
+}
+
 @keyframes feeling-saved {
   0%   { filter: brightness(1); }
   40%  { filter: brightness(1.35); }

--- a/app/controllers/admin/sites_controller.rb
+++ b/app/controllers/admin/sites_controller.rb
@@ -44,7 +44,8 @@ module Admin
         :calendar_tagline,
         :about,
         :shortname,
-        :listed
+        :listed,
+        :life_area
       )
     end
   end

--- a/app/controllers/admin/sites_controller.rb
+++ b/app/controllers/admin/sites_controller.rb
@@ -45,7 +45,7 @@ module Admin
         :about,
         :shortname,
         :listed,
-        :life_area
+        :category
       )
     end
   end

--- a/app/controllers/users/membership_orders_controller.rb
+++ b/app/controllers/users/membership_orders_controller.rb
@@ -1,0 +1,13 @@
+module Users
+  class MembershipOrdersController < ApplicationController
+    def update
+      ActiveRecord::Base.transaction do
+        params[:order].each_with_index do |id, index|
+          Current.user.memberships.where(id: id).update_all(position: index)
+        end
+      end
+
+      head :ok
+    end
+  end
+end

--- a/app/controllers/users/memberships_controller.rb
+++ b/app/controllers/users/memberships_controller.rb
@@ -3,7 +3,7 @@ module Users
     layout "overview"
 
     def show
-      @memberships = Current.user.memberships.includes(:platform).where.not(role: :invited).order(:created_at)
+      @memberships = Current.user.memberships.includes(:platform).where.not(role: :invited).order(:position, :created_at)
     end
   end
 end

--- a/app/javascript/controllers/assessments_controller.js
+++ b/app/javascript/controllers/assessments_controller.js
@@ -110,7 +110,7 @@ export default class extends Controller {
       font-size: 0.75rem;
       font-weight: 600;
       white-space: nowrap;
-      animation: label-dismiss 0.9s cubic-bezier(0.2, 0, 0.38, 1) forwards;
+      animation: label-dismiss 0.55s cubic-bezier(0.25, 0, 0.3, 1) forwards;
     `
     document.body.appendChild(clone)
     clone.addEventListener("animationend", () => clone.remove(), { once: true })

--- a/app/javascript/controllers/assessments_controller.js
+++ b/app/javascript/controllers/assessments_controller.js
@@ -13,7 +13,6 @@ export default class extends Controller {
   }
 
   sliderTargetDisconnected(slider) {
-    clearTimeout(this.labelTimers?.[slider.id])
     this.hideLabel(slider)
   }
 
@@ -21,8 +20,6 @@ export default class extends Controller {
     const slider = event.currentTarget
     this.updateTrackFill(slider)
     this.showLabel(slider)
-    clearTimeout(this.labelTimers?.[slider.id])
-
     if (parseInt(slider.value) === 100) this.emitSparks(slider)
   }
 
@@ -78,20 +75,30 @@ export default class extends Controller {
 
   dismissLabel(slider) {
     const label = document.getElementById(slider.dataset.labelId)
-    if (!label) return
+    if (!label || !label.textContent) return
 
-    clearTimeout(this.labelTimers?.[slider.id])
-    label.style.animation = "none"
-    label.offsetHeight // force reflow so re-adding animation starts fresh
+    const rect = label.getBoundingClientRect()
+    if (rect.width === 0) return
 
-    this.labelTimers ||= {}
-    this.labelTimers[slider.id] = setTimeout(() => {
-      label.style.animation = "label-dismiss 0.75s cubic-bezier(0.2, 0, 0.38, 1) forwards"
-      label.addEventListener("animationend", () => {
-        label.style.animation = ""
-        this.hideLabel(slider)
-      }, { once: true })
-    }, 400)
+    // Clone into body so Turbo Stream replacement doesn't interrupt the animation
+    const clone = document.createElement("span")
+    clone.textContent = label.textContent
+    clone.style.cssText = `
+      position: fixed;
+      left: ${rect.left + rect.width / 2}px;
+      top: ${rect.top}px;
+      color: ${label.style.color};
+      pointer-events: none;
+      z-index: 9999;
+      font-size: 0.75rem;
+      font-weight: 600;
+      white-space: nowrap;
+      animation: label-dismiss 0.9s cubic-bezier(0.2, 0, 0.38, 1) forwards;
+    `
+    document.body.appendChild(clone)
+    clone.addEventListener("animationend", () => clone.remove(), { once: true })
+
+    this.hideLabel(slider)
   }
 
   emitSparks(slider) {

--- a/app/javascript/controllers/assessments_controller.js
+++ b/app/javascript/controllers/assessments_controller.js
@@ -11,12 +11,16 @@ export default class extends Controller {
   }
 
   preview(event) {
-    this.updateTrackFill(event.currentTarget)
+    const slider = event.currentTarget
+    this.updateTrackFill(slider)
+    this.showLabel(slider)
+    clearTimeout(this.labelTimers?.[slider.id])
   }
 
   async save(event) {
     const slider = event.currentTarget
     this.updateTrackFill(slider)
+    this.scheduleHideLabel(slider)
 
     await fetch(slider.dataset.actionUrl, {
       method: "POST",
@@ -44,6 +48,19 @@ export default class extends Controller {
       label.style.color = color
       label.style.left = `${pct * (slider.offsetWidth - THUMB_WIDTH) + THUMB_WIDTH / 2}px`
     }
+  }
+
+  showLabel(slider) {
+    const label = document.getElementById(slider.dataset.labelId)
+    if (label) label.classList.replace("opacity-0", "opacity-100")
+  }
+
+  scheduleHideLabel(slider) {
+    this.labelTimers ||= {}
+    this.labelTimers[slider.id] = setTimeout(() => {
+      const label = document.getElementById(slider.dataset.labelId)
+      if (label) label.classList.replace("opacity-100", "opacity-0")
+    }, 1200)
   }
 
   feelingColor(pct) {

--- a/app/javascript/controllers/assessments_controller.js
+++ b/app/javascript/controllers/assessments_controller.js
@@ -29,7 +29,8 @@ export default class extends Controller {
   async save(event) {
     const slider = event.currentTarget
     this.updateTrackFill(slider)
-    this.scheduleHideLabel(slider)
+    this.showLabel(slider)
+    this.dismissLabel(slider)
 
     await fetch(slider.dataset.actionUrl, {
       method: "POST",
@@ -75,9 +76,22 @@ export default class extends Controller {
     }
   }
 
-  scheduleHideLabel(slider) {
+  dismissLabel(slider) {
+    const label = document.getElementById(slider.dataset.labelId)
+    if (!label) return
+
+    clearTimeout(this.labelTimers?.[slider.id])
+    label.style.animation = "none"
+    label.offsetHeight // force reflow so re-adding animation starts fresh
+
     this.labelTimers ||= {}
-    this.labelTimers[slider.id] = setTimeout(() => this.hideLabel(slider), 1200)
+    this.labelTimers[slider.id] = setTimeout(() => {
+      label.style.animation = "label-dismiss 0.75s cubic-bezier(0.2, 0, 0.38, 1) forwards"
+      label.addEventListener("animationend", () => {
+        label.style.animation = ""
+        this.hideLabel(slider)
+      }, { once: true })
+    }, 400)
   }
 
   emitSparks(slider) {

--- a/app/javascript/controllers/assessments_controller.js
+++ b/app/javascript/controllers/assessments_controller.js
@@ -1,13 +1,20 @@
 import { Controller } from "@hotwired/stimulus"
 
-const FEELING_LABELS = ["Calamity", "Critical", "Bad", "Not good", "Mid", "Ok", "Good", "Great", "Amazing", "Perfect"]
+const FEELING_LABELS = ["Terribly", "Poorly", "Worryingly", "Not good", "Meh", "Ok", "Good", "Great", "Amazing", "Perfect"]
 const THUMB_WIDTH = 18
+const SPARK_COLORS = ["#4ade80", "#facc15", "#fb923c", "#a78bfa", "#38bdf8"]
 
 export default class extends Controller {
   static targets = ["slider"]
 
   sliderTargetConnected(slider) {
     this.updateTrackFill(slider)
+    this.hideLabel(slider)
+  }
+
+  sliderTargetDisconnected(slider) {
+    clearTimeout(this.labelTimers?.[slider.id])
+    this.hideLabel(slider)
   }
 
   preview(event) {
@@ -15,6 +22,8 @@ export default class extends Controller {
     this.updateTrackFill(slider)
     this.showLabel(slider)
     clearTimeout(this.labelTimers?.[slider.id])
+
+    if (parseInt(slider.value) === 100) this.emitSparks(slider)
   }
 
   async save(event) {
@@ -52,15 +61,54 @@ export default class extends Controller {
 
   showLabel(slider) {
     const label = document.getElementById(slider.dataset.labelId)
-    if (label) label.classList.replace("opacity-0", "opacity-100")
+    if (label) {
+      label.classList.remove("opacity-0")
+      label.classList.add("opacity-100")
+    }
+  }
+
+  hideLabel(slider) {
+    const label = document.getElementById(slider.dataset.labelId)
+    if (label) {
+      label.classList.remove("opacity-100")
+      label.classList.add("opacity-0")
+    }
   }
 
   scheduleHideLabel(slider) {
     this.labelTimers ||= {}
-    this.labelTimers[slider.id] = setTimeout(() => {
-      const label = document.getElementById(slider.dataset.labelId)
-      if (label) label.classList.replace("opacity-100", "opacity-0")
-    }, 1200)
+    this.labelTimers[slider.id] = setTimeout(() => this.hideLabel(slider), 1200)
+  }
+
+  emitSparks(slider) {
+    const rect = slider.getBoundingClientRect()
+    const thumbX = rect.left + rect.width - THUMB_WIDTH / 2
+    const thumbY = rect.top + rect.height / 2
+
+    for (let i = 0; i < 8; i++) {
+      const spark = document.createElement("span")
+      const color = SPARK_COLORS[i % SPARK_COLORS.length]
+      const angle = (i / 8) * 2 * Math.PI
+      const distance = 28 + Math.random() * 18
+      const tx = Math.cos(angle) * distance
+      const ty = Math.sin(angle) * distance
+
+      spark.style.cssText = `
+        position: fixed;
+        pointer-events: none;
+        width: 5px; height: 5px;
+        border-radius: 50%;
+        background: ${color};
+        left: ${thumbX}px;
+        top: ${thumbY}px;
+        transform: translate(-50%, -50%);
+        animation: spark-fly 0.55s ease-out forwards;
+        --tx: ${tx}px; --ty: ${ty}px;
+        z-index: 9999;
+      `
+      document.body.appendChild(spark)
+      spark.addEventListener("animationend", () => spark.remove(), { once: true })
+    }
   }
 
   feelingColor(pct) {

--- a/app/javascript/controllers/assessments_controller.js
+++ b/app/javascript/controllers/assessments_controller.js
@@ -8,6 +8,8 @@ export default class extends Controller {
   static targets = ["slider"]
 
   sliderTargetConnected(slider) {
+    const latest = this.latestValues?.[slider.dataset.labelId]
+    if (latest !== undefined && parseInt(slider.value) !== latest) slider.value = latest
     this.updateTrackFill(slider)
     this.hideLabel(slider)
   }
@@ -25,18 +27,33 @@ export default class extends Controller {
 
   async save(event) {
     const slider = event.currentTarget
+    const key = slider.dataset.labelId
+
+    this.saveControllers ||= {}
+    this.saveControllers[key]?.abort()
+    this.saveControllers[key] = new AbortController()
+
+    this.latestValues ||= {}
+    this.latestValues[key] = parseInt(slider.value)
+
     this.updateTrackFill(slider)
     this.showLabel(slider)
     this.dismissLabel(slider)
 
-    await fetch(slider.dataset.actionUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-CSRF-Token": document.querySelector("meta[name='csrf-token']").content
-      },
-      body: JSON.stringify({ value: slider.value })
-    })
+    try {
+      await fetch(slider.dataset.actionUrl, {
+        method: "POST",
+        signal: this.saveControllers[key].signal,
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRF-Token": document.querySelector("meta[name='csrf-token']").content
+        },
+        body: JSON.stringify({ value: slider.value })
+      })
+    } catch (e) {
+      if (e.name !== "AbortError") throw e
+      return
+    }
 
     slider.classList.add("feeling-saved")
     slider.addEventListener("animationend", () => slider.classList.remove("feeling-saved"), { once: true })

--- a/app/javascript/controllers/assessments_controller.js
+++ b/app/javascript/controllers/assessments_controller.js
@@ -1,5 +1,8 @@
 import { Controller } from "@hotwired/stimulus"
 
+const FEELING_LABELS = ["Calamity", "Critical", "Bad", "Not good", "Mid", "Ok", "Good", "Great", "Amazing", "Perfect"]
+const THUMB_WIDTH = 18
+
 export default class extends Controller {
   static targets = ["slider"]
 
@@ -34,6 +37,13 @@ export default class extends Controller {
     slider.style.setProperty("--fill-pct", `${pct * 100}%`)
     slider.style.setProperty("--fill-color", color)
     slider.style.setProperty("--glow-color", color.replace("rgb(", "rgba(").replace(")", ", 0.28)"))
+
+    const label = document.getElementById(slider.dataset.labelId)
+    if (label) {
+      label.textContent = FEELING_LABELS[Math.min(Math.floor(pct * 10), 9)]
+      label.style.color = color
+      label.style.left = `${pct * (slider.offsetWidth - THUMB_WIDTH) + THUMB_WIDTH / 2}px`
+    }
   }
 
   feelingColor(pct) {

--- a/app/javascript/controllers/sortable_controller.js
+++ b/app/javascript/controllers/sortable_controller.js
@@ -3,12 +3,13 @@ import Sortable from "sortablejs";
 import {request} from "helpers/request_helpers";
 
 export default class extends Controller {
-    static values = {updatePath: String};
+    static values = {updatePath: String, handle: String};
 
     connect() {
         this.sortable = Sortable.create(this.element, {
             animation: 150,
             ghostClass: "bg-gray-200",
+            handle: this.hasHandleValue ? this.handleValue : undefined,
             onEnd: this.reorder.bind(this),
         });
     }

--- a/app/javascript/controllers/tab_bar_controller.js
+++ b/app/javascript/controllers/tab_bar_controller.js
@@ -1,0 +1,25 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = { active: { type: String, default: "work" }, storageKey: String }
+  static targets = ["tab", "panel"]
+
+  connect() {
+    if (this.hasStorageKeyValue) {
+      const stored = localStorage.getItem(this.storageKeyValue)
+      if (stored) this.activeValue = stored
+    }
+  }
+
+  select(event) {
+    this.activeValue = event.currentTarget.dataset.tab
+    if (this.hasStorageKeyValue) {
+      localStorage.setItem(this.storageKeyValue, this.activeValue)
+    }
+  }
+
+  activeValueChanged(value) {
+    this.tabTargets.forEach(tab => tab.classList.toggle("tab-active", tab.dataset.tab === value))
+    this.panelTargets.forEach(panel => { panel.hidden = panel.dataset.tab !== value })
+  }
+}

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -12,6 +12,8 @@ class Membership < ApplicationRecord
 
   enum :role, %i[member admin super_admin invited]
 
+  before_create :set_position
+
   validate :role_was_not_set_back_to_invited, if: :role_changed?
 
   table_filter_by %w[role]
@@ -49,5 +51,9 @@ class Membership < ApplicationRecord
 
   def role_was_not_set_back_to_invited
     self.errors.add(:role, "Can't be changed back to invited") if invited? && role_was != "invited"
+  end
+
+  def set_position
+    self.position = Membership.where(user_id: user_id).maximum(:position).to_i + 1
   end
 end

--- a/app/models/platform.rb
+++ b/app/models/platform.rb
@@ -7,6 +7,7 @@ class Platform < ApplicationRecord
   has_many :links, dependent: :destroy
 
   enum :category, { unorganised: "unorganised", shareholder_org: "shareholder_org", member_org: "member_org" }
+  enum :life_area, { work: "work", personal: "personal" }
 
   scope :listed, -> { where(listed: true) }
 

--- a/app/models/platform.rb
+++ b/app/models/platform.rb
@@ -6,8 +6,7 @@ class Platform < ApplicationRecord
   has_many :meetings, dependent: :delete_all
   has_many :links, dependent: :destroy
 
-  enum :category, { unorganised: "unorganised", shareholder_org: "shareholder_org", member_org: "member_org" }
-  enum :life_area, { work: "work", personal: "personal" }
+  enum :category, { work: "work", personal: "personal" }
 
   scope :listed, -> { where(listed: true) }
 

--- a/app/views/admin/sites/_form.html.erb
+++ b/app/views/admin/sites/_form.html.erb
@@ -45,6 +45,20 @@
 
 
   <div class="form-group">
+    <%= form.label :life_area, "Category" %>
+    <div class="flex gap-4 mt-2">
+      <% [["💼 Work", "work"], ["🌱 Personal", "personal"]].each do |label, value| %>
+        <label class="flex items-center gap-2 cursor-pointer">
+          <%= form.radio_button :life_area, value,
+                                class: "radio radio-sm",
+                                data: { action: "change->submit-on-change#submit" } %>
+          <span><%= label %></span>
+        </label>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="form-group">
     <%= form.label :shortname,
                    "Your URL",
                    maxLength: 20 %>

--- a/app/views/admin/sites/_form.html.erb
+++ b/app/views/admin/sites/_form.html.erb
@@ -45,11 +45,11 @@
 
 
   <div class="form-group">
-    <%= form.label :life_area, "Category" %>
+    <%= form.label :category, "Category" %>
     <div class="flex gap-4 mt-2">
       <% [["💼 Work", "work"], ["🌱 Personal", "personal"]].each do |label, value| %>
         <label class="flex items-center gap-2 cursor-pointer">
-          <%= form.radio_button :life_area, value,
+          <%= form.radio_button :category, value,
                                 class: "radio radio-sm",
                                 data: { action: "change->submit-on-change#submit" } %>
           <span><%= label %></span>

--- a/app/views/users/assessments/_slider.html.erb
+++ b/app/views/users/assessments/_slider.html.erb
@@ -1,12 +1,19 @@
 <%# locals: (membership:) %>
-<input
-  type="range"
-  min="0"
-  max="100"
-  value="<%= membership.feeling || 50 %>"
-  id="<%= dom_id(membership, :assessment) %>"
-  class="memberships-slider w-full"
-  data-assessments-target="slider"
-  data-action-url="<%= users_membership_assessments_path(membership) %>"
-  data-action="input->assessments#preview change->assessments#save"
->
+<div class="relative pb-6">
+  <input
+    type="range"
+    min="0"
+    max="100"
+    value="<%= membership.feeling || 50 %>"
+    id="<%= dom_id(membership, :assessment) %>"
+    class="memberships-slider w-full"
+    data-assessments-target="slider"
+    data-label-id="<%= dom_id(membership, :assessment_label) %>"
+    data-action-url="<%= users_membership_assessments_path(membership) %>"
+    data-action="input->assessments#preview change->assessments#save"
+  >
+  <span
+    id="<%= dom_id(membership, :assessment_label) %>"
+    class="absolute top-[22px] text-xs font-semibold whitespace-nowrap -translate-x-1/2"
+  ></span>
+</div>

--- a/app/views/users/assessments/_slider.html.erb
+++ b/app/views/users/assessments/_slider.html.erb
@@ -14,6 +14,6 @@
   >
   <span
     id="<%= dom_id(membership, :assessment_label) %>"
-    class="absolute top-[22px] text-xs font-semibold whitespace-nowrap -translate-x-1/2"
+    class="absolute top-[22px] text-xs font-semibold whitespace-nowrap -translate-x-1/2 opacity-0 transition-opacity duration-300"
   ></span>
 </div>

--- a/app/views/users/assessments/_slider.html.erb
+++ b/app/views/users/assessments/_slider.html.erb
@@ -1,5 +1,5 @@
 <%# locals: (membership:) %>
-<div class="relative pb-6">
+<div class="relative pb-5">
   <input
     type="range"
     min="0"

--- a/app/views/users/assessments/_slider.html.erb
+++ b/app/views/users/assessments/_slider.html.erb
@@ -1,11 +1,10 @@
 <%# locals: (membership:) %>
-<div class="relative pb-5">
+<div id="<%= dom_id(membership, :assessment) %>" class="relative pb-5">
   <input
     type="range"
     min="0"
     max="100"
     value="<%= membership.feeling || 50 %>"
-    id="<%= dom_id(membership, :assessment) %>"
     class="memberships-slider w-full"
     data-assessments-target="slider"
     data-label-id="<%= dom_id(membership, :assessment_label) %>"

--- a/app/views/users/memberships/show.html.erb
+++ b/app/views/users/memberships/show.html.erb
@@ -8,24 +8,32 @@
 
   <div class="space-y-4"
        data-controller="sortable"
-       data-sortable-update-path-value="<%= users_membership_order_path %>">
+       data-sortable-update-path-value="<%= users_membership_order_path %>"
+       data-sortable-handle-value=".drag-handle">
     <% @memberships.each do |membership| %>
-      <div class="membership-card p-5 cursor-grab active:cursor-grabbing" data-id="<%= membership.id %>">
+      <div class="membership-card flex items-stretch" data-id="<%= membership.id %>">
 
-        <div class="flex items-start justify-between mb-5">
-          <div class="flex-1 min-w-0 pr-4">
-            <%= link_to membership.platform.name,
-                        users_membership_switch_path(membership),
-                        data: { turbo_method: :post },
-                        class: "block text-xl font-display font-semibold text-gray-900 leading-tight truncate" %>
-          </div>
-          <%= link_to "→",
-                      users_membership_switch_path(membership),
-                      data: { turbo_method: :post },
-                      class: "text-gray-300 hover:text-gray-900 transition-colors text-xl mt-1 flex-shrink-0" %>
+        <div class="drag-handle flex items-center px-3 text-gray-300 hover:text-gray-400 cursor-grab active:cursor-grabbing">
+          <%= svg_tag "icons/mingcute/dot_grid_line.svg", class: "w-5 h-5" %>
         </div>
 
-        <%= render "users/assessments/slider", membership: membership %>
+        <div class="flex-1 p-5 min-w-0">
+          <div class="flex items-start justify-between mb-5">
+            <div class="flex-1 min-w-0 pr-4">
+              <%= link_to membership.platform.name,
+                          users_membership_switch_path(membership),
+                          data: { turbo_method: :post },
+                          class: "block text-xl font-display font-semibold text-gray-900 leading-tight truncate" %>
+            </div>
+            <%= link_to "→",
+                        users_membership_switch_path(membership),
+                        data: { turbo_method: :post },
+                        class: "text-gray-300 hover:text-gray-900 transition-colors text-xl mt-1 flex-shrink-0" %>
+          </div>
+
+          <%= render "users/assessments/slider", membership: membership %>
+        </div>
+
       </div>
     <% end %>
   </div>

--- a/app/views/users/memberships/show.html.erb
+++ b/app/views/users/memberships/show.html.erb
@@ -14,7 +14,7 @@
   </div>
 
   <% %w[work personal].each do |area| %>
-    <% area_memberships = @memberships.select { |m| m.platform.life_area == area } %>
+    <% area_memberships = @memberships.select { |m| m.platform.category == area } %>
     <div data-tab="<%= area %>" data-tab-bar-target="panel">
       <% if area_memberships.any? %>
         <div class="space-y-2"

--- a/app/views/users/memberships/show.html.erb
+++ b/app/views/users/memberships/show.html.erb
@@ -1,14 +1,16 @@
 <%= turbo_stream_from Current.user, :memberships %>
 
-<div class="w-full max-w-lg mx-auto" data-controller="assessments">
+<div class="w-full max-w-md mx-auto" data-controller="assessments">
 
   <div class="mb-10">
     <h1 class="text-4xl font-display font-semibold text-gray-900 leading-tight">How do you feel it's going?</h1>
   </div>
 
-  <div class="space-y-4">
+  <div class="space-y-4"
+       data-controller="sortable"
+       data-sortable-update-path-value="<%= users_membership_order_path %>">
     <% @memberships.each do |membership| %>
-      <div class="membership-card p-5">
+      <div class="membership-card p-5 cursor-grab active:cursor-grabbing" data-id="<%= membership.id %>">
 
         <div class="flex items-start justify-between mb-5">
           <div class="flex-1 min-w-0 pr-4">
@@ -26,7 +28,9 @@
         <%= render "users/assessments/slider", membership: membership %>
       </div>
     <% end %>
+  </div>
 
+  <div class="mt-4">
     <div class="add-platform-card p-5 flex items-center justify-center">
       <%= modal_link_to new_users_platform_path, class: "flex items-center gap-3 group" do %>
         <%= svg_tag "icons/mingcute/add_circle_line.svg", class: "w-6 h-6 flex-shrink-0" %>

--- a/app/views/users/memberships/show.html.erb
+++ b/app/views/users/memberships/show.html.erb
@@ -15,7 +15,7 @@
             <%= link_to membership.platform.name,
                         users_membership_switch_path(membership),
                         data: { turbo_method: :post },
-                        class: "block text-xl font-display font-semibold text-gray-900 leading-tight hover:opacity-60 transition-opacity truncate" %>
+                        class: "block text-xl font-display font-semibold text-gray-900 leading-tight truncate" %>
           </div>
           <%= link_to "→",
                       users_membership_switch_path(membership),

--- a/app/views/users/memberships/show.html.erb
+++ b/app/views/users/memberships/show.html.erb
@@ -1,12 +1,12 @@
 <%= turbo_stream_from Current.user, :memberships %>
 
-<div class="w-full max-w-md mx-auto" data-controller="assessments">
+<div class="w-full max-w-lg mx-auto" data-controller="assessments">
 
   <div class="mb-10">
     <h1 class="text-4xl font-display font-semibold text-gray-900 leading-tight">How do you feel it's going?</h1>
   </div>
 
-  <div class="space-y-4"
+  <div class="space-y-2"
        data-controller="sortable"
        data-sortable-update-path-value="<%= users_membership_order_path %>"
        data-sortable-handle-value=".drag-handle">
@@ -17,8 +17,8 @@
           <%= svg_tag "icons/mingcute/dot_grid_line.svg", class: "w-5 h-5" %>
         </div>
 
-        <div class="flex-1 p-5 min-w-0">
-          <div class="flex items-start justify-between mb-5">
+        <div class="flex-1 py-3 pr-4 min-w-0">
+          <div class="flex items-start justify-between mb-3">
             <div class="flex-1 min-w-0 pr-4">
               <%= link_to membership.platform.name,
                           users_membership_switch_path(membership),
@@ -38,8 +38,8 @@
     <% end %>
   </div>
 
-  <div class="mt-4">
-    <div class="add-platform-card p-5 flex items-center justify-center">
+  <div class="mt-2">
+    <div class="add-platform-card py-3 px-5 flex items-center justify-center">
       <%= modal_link_to new_users_platform_path, class: "flex items-center gap-3 group" do %>
         <%= svg_tag "icons/mingcute/add_circle_line.svg", class: "w-6 h-6 flex-shrink-0" %>
         <span class="text-base font-semibold">Work on something new</span>

--- a/app/views/users/memberships/show.html.erb
+++ b/app/views/users/memberships/show.html.erb
@@ -1,33 +1,48 @@
 <%= turbo_stream_from Current.user, :memberships %>
 
-<div class="w-full max-w-lg mx-auto" data-controller="assessments">
+<div class="w-full max-w-lg mx-auto"
+     data-controller="assessments tab-bar"
+     data-tab-bar-storage-key-value="membership-dashboard-area">
 
-  <div class="mb-10">
-    <h1 class="text-4xl font-display font-semibold text-gray-900 leading-tight">How do you feel it's going?</h1>
+  <div class="mb-8">
+    <h1 class="text-4xl font-display font-semibold text-gray-900 leading-tight mb-5">How do you feel it's going?</h1>
+
+    <div class="tabs tabs-box" role="tablist">
+      <button class="tab" data-tab="work" data-tab-bar-target="tab" data-action="click->tab-bar#select">💼 Work</button>
+      <button class="tab" data-tab="personal" data-tab-bar-target="tab" data-action="click->tab-bar#select">🌱 Personal</button>
+    </div>
   </div>
 
-  <div class="space-y-2"
-       data-controller="sortable"
-       data-sortable-update-path-value="<%= users_membership_order_path %>"
-       data-sortable-handle-value=".drag-handle">
-    <% @memberships.each do |membership| %>
-      <div class="membership-card p-4" data-id="<%= membership.id %>">
+  <% %w[work personal].each do |area| %>
+    <% area_memberships = @memberships.select { |m| m.platform.life_area == area } %>
+    <div data-tab="<%= area %>" data-tab-bar-target="panel">
+      <% if area_memberships.any? %>
+        <div class="space-y-2"
+             data-controller="sortable"
+             data-sortable-update-path-value="<%= users_membership_order_path %>"
+             data-sortable-handle-value=".drag-handle">
+          <% area_memberships.each do |membership| %>
+            <div class="membership-card p-4" data-id="<%= membership.id %>">
 
-        <div class="flex items-center justify-between mb-3">
-          <%= link_to membership.platform.name,
-                      users_membership_switch_path(membership),
-                      data: { turbo_method: :post },
-                      class: "block text-xl font-display font-semibold text-gray-900 leading-tight truncate flex-1 min-w-0 pr-3" %>
-          <div class="drag-handle text-gray-300 hover:text-gray-400 cursor-grab active:cursor-grabbing flex-shrink-0">
-            <%= svg_tag "icons/mingcute/dot_grid_line.svg", class: "w-5 h-5" %>
-          </div>
+              <div class="flex items-center justify-between mb-3">
+                <%= link_to membership.platform.name,
+                            users_membership_switch_path(membership),
+                            data: { turbo_method: :post },
+                            class: "block text-xl font-display font-semibold text-gray-900 leading-tight truncate flex-1 min-w-0 pr-3" %>
+                <div class="drag-handle text-gray-300 hover:text-gray-400 cursor-grab active:cursor-grabbing flex-shrink-0">
+                  <%= svg_tag "icons/mingcute/dot_grid_line.svg", class: "w-5 h-5" %>
+                </div>
+              </div>
+
+              <%= render "users/assessments/slider", membership: membership %>
+            </div>
+          <% end %>
         </div>
-
-        <%= render "users/assessments/slider", membership: membership %>
-
-      </div>
-    <% end %>
-  </div>
+      <% else %>
+        <p class="text-sm text-gray-400 text-center py-6">No <%= area %> platforms yet.</p>
+      <% end %>
+    </div>
+  <% end %>
 
   <div class="mt-2">
     <div class="add-platform-card py-3 px-5 flex items-center justify-center">

--- a/app/views/users/memberships/show.html.erb
+++ b/app/views/users/memberships/show.html.erb
@@ -11,28 +11,19 @@
        data-sortable-update-path-value="<%= users_membership_order_path %>"
        data-sortable-handle-value=".drag-handle">
     <% @memberships.each do |membership| %>
-      <div class="membership-card flex items-stretch" data-id="<%= membership.id %>">
+      <div class="membership-card p-4" data-id="<%= membership.id %>">
 
-        <div class="drag-handle flex items-center px-3 text-gray-300 hover:text-gray-400 cursor-grab active:cursor-grabbing">
-          <%= svg_tag "icons/mingcute/dot_grid_line.svg", class: "w-5 h-5" %>
-        </div>
-
-        <div class="flex-1 py-3 pr-4 min-w-0">
-          <div class="flex items-start justify-between mb-3">
-            <div class="flex-1 min-w-0 pr-4">
-              <%= link_to membership.platform.name,
-                          users_membership_switch_path(membership),
-                          data: { turbo_method: :post },
-                          class: "block text-xl font-display font-semibold text-gray-900 leading-tight truncate" %>
-            </div>
-            <%= link_to "→",
-                        users_membership_switch_path(membership),
-                        data: { turbo_method: :post },
-                        class: "text-gray-300 hover:text-gray-900 transition-colors text-xl mt-1 flex-shrink-0" %>
+        <div class="flex items-center justify-between mb-3">
+          <%= link_to membership.platform.name,
+                      users_membership_switch_path(membership),
+                      data: { turbo_method: :post },
+                      class: "block text-xl font-display font-semibold text-gray-900 leading-tight truncate flex-1 min-w-0 pr-3" %>
+          <div class="drag-handle text-gray-300 hover:text-gray-400 cursor-grab active:cursor-grabbing flex-shrink-0">
+            <%= svg_tag "icons/mingcute/dot_grid_line.svg", class: "w-5 h-5" %>
           </div>
-
-          <%= render "users/assessments/slider", membership: membership %>
         </div>
+
+        <%= render "users/assessments/slider", membership: membership %>
 
       </div>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,7 @@ Rails.application.routes.draw do
       resource :switch, only: [ :create ], module: :memberships
     end
     resource :platform, only: [ :new, :create ]
+    resource :membership_order, only: [ :update ]
   end
 
   namespace :admin do

--- a/db/migrate/20260406000001_add_position_to_memberships.rb
+++ b/db/migrate/20260406000001_add_position_to_memberships.rb
@@ -1,0 +1,15 @@
+class AddPositionToMemberships < ActiveRecord::Migration[8.0]
+  def up
+    add_column :memberships, :position, :integer
+
+    User.find_each do |user|
+      user.memberships.order(:created_at).each_with_index do |membership, index|
+        membership.update_column(:position, index)
+      end
+    end
+  end
+
+  def down
+    remove_column :memberships, :position
+  end
+end

--- a/db/migrate/20260407000001_add_life_area_to_platforms.rb
+++ b/db/migrate/20260407000001_add_life_area_to_platforms.rb
@@ -1,0 +1,5 @@
+class AddLifeAreaToPlatforms < ActiveRecord::Migration[8.0]
+  def change
+    add_column :platforms, :life_area, :string, default: "work", null: false
+  end
+end

--- a/db/migrate/20260407000002_replace_category_with_work_personal_on_platforms.rb
+++ b/db/migrate/20260407000002_replace_category_with_work_personal_on_platforms.rb
@@ -1,0 +1,6 @@
+class ReplaceCategoryWithWorkPersonalOnPlatforms < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :platforms, :category, :string, null: false, default: "unorganised"
+    rename_column :platforms, :life_area, :category
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_04_07_000001) do
+ActiveRecord::Schema[8.0].define(version: 2026_04_07_000002) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -161,13 +161,12 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_07_000001) do
     t.string "shortname"
     t.boolean "listed"
     t.string "tagline"
-    t.string "category", default: "unorganised", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "calendar_tagline"
     t.string "domain"
     t.string "color"
-    t.string "life_area", default: "work", null: false
+    t.string "category", default: "work", null: false
     t.index ["shortname"], name: "index_platforms_on_shortname", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_04_06_000001) do
+ActiveRecord::Schema[8.0].define(version: 2026_04_07_000001) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -167,6 +167,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_06_000001) do
     t.string "calendar_tagline"
     t.string "domain"
     t.string "color"
+    t.string "life_area", default: "work", null: false
     t.index ["shortname"], name: "index_platforms_on_shortname", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_04_06_000000) do
+ActiveRecord::Schema[8.0].define(version: 2026_04_06_000001) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -140,6 +140,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_06_000000) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "feeling"
+    t.integer "position"
     t.index ["platform_id", "user_id"], name: "index_memberships_on_platform_id_and_user_id", unique: true
     t.index ["platform_id"], name: "index_memberships_on_platform_id"
     t.index ["user_id"], name: "index_memberships_on_user_id"

--- a/test/controllers/users/membership_orders_controller_test.rb
+++ b/test/controllers/users/membership_orders_controller_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+module Users
+  class MembershipOrdersControllerTest < ActionDispatch::IntegrationTest
+    test "#update succeeds" do
+      login_as users(:me), on: platforms(:coffee_shop)
+      new_order = [
+        memberships(:you_organise_the_football_meetup).id,
+        memberships(:you_manage_the_coffee_shop).id,
+        memberships(:you_sit_on_the_political_chapter_board).id
+      ]
+      patch users_membership_order_path, params: { order: new_order }, as: :json
+      assert_response :ok
+      assert_equal 0, memberships(:you_organise_the_football_meetup).reload.position
+      assert_equal 1, memberships(:you_manage_the_coffee_shop).reload.position
+      assert_equal 2, memberships(:you_sit_on_the_political_chapter_board).reload.position
+    end
+
+    test "#update redirects to login if not authenticated" do
+      patch users_membership_order_path, params: { order: [] }, as: :json
+      assert_redirected_to new_session_path
+    end
+  end
+end

--- a/test/fixtures/memberships.yml
+++ b/test/fixtures/memberships.yml
@@ -2,16 +2,19 @@ you_manage_the_coffee_shop:
   user: me
   platform: coffee_shop
   role: super_admin
+  position: 0
 
 you_sit_on_the_political_chapter_board:
   user: me
   platform: political_chapter
   role: super_admin
+  position: 1
 
 you_organise_the_football_meetup:
   user: me
   platform: football_meetup
   role: super_admin
+  position: 2
 
 dave_is_a_coffee_shop_shareholder:
   user: dave

--- a/test/fixtures/platforms.yml
+++ b/test/fixtures/platforms.yml
@@ -1,23 +1,20 @@
 football_meetup:
   name: Casual Football Meetup
-  category: 0
   shortname: footballmeetup
   listed: true
-  life_area: personal
+  category: personal
 
 coffee_shop:
   name: Spring Coffee
-  category: 1
   shortname: springcoffee
   listed: false
   domain: unlisted.lvh.me
-  life_area: work
+  category: work
 
 political_chapter:
   name: Kjelsås Labour Party
-  category: 2
   shortname: kjelsasap
   listed: true
   domain: kjelsasap.lvh.me
   color: "#ffffff"
-  life_area: work
+  category: work

--- a/test/fixtures/platforms.yml
+++ b/test/fixtures/platforms.yml
@@ -3,6 +3,7 @@ football_meetup:
   category: 0
   shortname: footballmeetup
   listed: true
+  life_area: personal
 
 coffee_shop:
   name: Spring Coffee
@@ -10,6 +11,7 @@ coffee_shop:
   shortname: springcoffee
   listed: false
   domain: unlisted.lvh.me
+  life_area: work
 
 political_chapter:
   name: Kjelsås Labour Party
@@ -18,3 +20,4 @@ political_chapter:
   listed: true
   domain: kjelsasap.lvh.me
   color: "#ffffff"
+  life_area: work

--- a/test/routing/custom_domain_root_routing_test.rb
+++ b/test/routing/custom_domain_root_routing_test.rb
@@ -6,12 +6,9 @@ class CustomDomainRootRoutingTest < ActionDispatch::IntegrationTest
   end
 
   test "primary domain routes root to welcome#index" do
-    env = Rack::MockRequest.env_for("http://localhost/")
-    req = ActionDispatch::Request.new(env)
-    found = nil
-    Rails.application.routes.router.recognize(req) { |_route, params| found = params }
-    assert_equal "welcome", found[:controller]
-    assert_equal "index", found[:action]
+    get "/"
+    assert_equal "welcome", @controller.controller_name
+    assert_equal "index", @controller.action_name
   end
 
   test "root on political_chapter's custom domain routes to public/platforms#show" do


### PR DESCRIPTION
Adds drag-and-drop reordering to the membership dashboard (sortable cards via a grip handle, persisted position column), and polishes the feeling slider: a word label tracks the thumb live, popping and floating away on release with a punchy animation. Hitting 100 emits coloured particle sparks.

Also fixes two bugs found during development: a Turbo Stream target mismatch that caused duplicate label spans to accumulate after each save, and a race condition where rapid slider moves sent multiple in-flight requests whose out-of-order responses would overwrite the UI with a stale value (fixed with AbortController + client-side last-value correction).

Minor UX tweaks: card titles no longer change colour on hover, card height reduced, arrow link replaced by the drag handle.