### PR TITLE
Center Work/Personal tabs and show active state

### DIFF
--- a/app/assets/stylesheets/custom/memberships.css
+++ b/app/assets/stylesheets/custom/memberships.css
@@ -1,3 +1,25 @@
+/* Tab bar */
+
+.tab {
+  padding: 0.375rem 1rem;
+  border-radius: 9999px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #6b7280;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.tab:hover {
+  color: #374151;
+}
+
+.tab.tab-active {
+  background: white;
+  color: #111827;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+}
+
 /* Memberships home */
 
 .membership-card {

--- a/app/views/users/memberships/show.html.erb
+++ b/app/views/users/memberships/show.html.erb
@@ -7,9 +7,11 @@
   <div class="mb-8">
     <h1 class="text-4xl font-display font-semibold text-gray-900 leading-tight mb-5">How do you feel it's going?</h1>
 
-    <div class="tabs tabs-box justify-center" role="tablist">
-      <button class="tab" data-tab="work" data-tab-bar-target="tab" data-action="click->tab-bar#select">💼 Work</button>
-      <button class="tab" data-tab="personal" data-tab-bar-target="tab" data-action="click->tab-bar#select">🌱 Personal</button>
+    <div class="flex justify-center">
+      <div class="inline-flex bg-gray-100 rounded-full p-1" role="tablist">
+        <button class="tab" data-tab="work" data-tab-bar-target="tab" data-action="click->tab-bar#select">💼 Work</button>
+        <button class="tab" data-tab="personal" data-tab-bar-target="tab" data-action="click->tab-bar#select">🌱 Personal</button>
+      </div>
     </div>
   </div>
 

--- a/app/views/users/memberships/show.html.erb
+++ b/app/views/users/memberships/show.html.erb
@@ -7,7 +7,7 @@
   <div class="mb-8">
     <h1 class="text-4xl font-display font-semibold text-gray-900 leading-tight mb-5">How do you feel it's going?</h1>
 
-    <div class="tabs tabs-box" role="tablist">
+    <div class="tabs tabs-box justify-center" role="tablist">
       <button class="tab" data-tab="work" data-tab-bar-target="tab" data-action="click->tab-bar#select">💼 Work</button>
       <button class="tab" data-tab="personal" data-tab-bar-target="tab" data-action="click->tab-bar#select">🌱 Personal</button>
     </div>


### PR DESCRIPTION
Centers the Work/Personal tab switcher on the membership dashboard and makes the selected tab visually distinct. The tab bar now renders as a pill-style toggle (gray background container, white active pill with shadow). Since daisyUI isn't installed, the `tabs-box`/`tab-active` classes had no effect — replaced with explicit Tailwind classes and custom CSS in `memberships.css`.